### PR TITLE
Fix async keyword

### DIFF
--- a/robovat/robots/robot_command.py
+++ b/robovat/robots/robot_command.py
@@ -17,7 +17,7 @@ class RobotCommand(object):
                  command_type,
                  arguments,
                  timeout=None,
-                 async=False):
+                 is_async=False):
         """Initialize.
 
         Args:
@@ -31,4 +31,4 @@ class RobotCommand(object):
         self.command_type = command_type
         self.arguments = arguments
         self.timeout = timeout
-        self.async = async
+        self.is_async = is_async


### PR DESCRIPTION
* Rename `async` variable to `is_async` since it is a reserved key word in python 3.7

Resolves #2 